### PR TITLE
Disable Packet Caches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM docker:latest
 
-RUN apk --update add openssh-client python python3-dev libffi-dev openssl-dev gcc libc-dev make \
-    && pip3 install docker-compose
+RUN apk  --no-cache add openssh-client python python3-dev libffi-dev openssl-dev gcc libc-dev make \
+    && pip3 install --no-cache-dir docker-compose


### PR DESCRIPTION
This patch disables the caches for `apk` and `pip` which will otherwise
end up in the containers, resulting in significant larger images.