### PR TITLE
Use Stable Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:latest
+FROM docker:stable
 
 RUN apk --update add openssh-client python python3-dev libffi-dev openssl-dev gcc libc-dev make \
     && pip3 install docker-compose


### PR DESCRIPTION
While `stable` and `latest` [is technically identical](https://hub.docker.com/_/docker), `latest` implies that the base image used is the newest (latest) image built which is not true. The tag `stable` is much more helpful in figuring out which version is used.