### PR TITLE
Updater prerequisites

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM docker:stable
 
-RUN apk  --no-cache add openssh-client python python3-dev libffi-dev openssl-dev gcc libc-dev make \
+RUN apk --no-cache add openssh-client python3 python3-dev py3-pip libffi-dev openssl-dev gcc libc-dev make \
     && pip3 install --no-cache-dir docker-compose


### PR DESCRIPTION
Python is now called `python3` and pip is installed via `py3-pip` in alpine.